### PR TITLE
feat: Add ATRA (ArticleTranslation) line type

### DIFF
--- a/LineFactory.php
+++ b/LineFactory.php
@@ -38,6 +38,7 @@ use NumaxLab\Geslib\Lines\Type;
 use NumaxLab\Geslib\Lines\Warning;
 use NumaxLab\Geslib\Lines\ArticleResource;
 use NumaxLab\Geslib\Lines\ArticleGpsr;
+use NumaxLab\Geslib\Lines\ArticleTranslation;
 
 final class LineFactory
 {
@@ -80,7 +81,7 @@ final class LineFactory
         ArticleBatchLine::CODE => ArticleBatchLine::class,
         Type::CODE => Type::class,
         Classification::CODE => Classification::class,
-        'ATRA' => null,
+        ArticleTranslation::CODE => ArticleTranslation::class,
         'CLOTCLI' => null,
         'LLOTCLI' => null,
         'PROFES' => null,

--- a/Lines/ArticleTranslation.php
+++ b/Lines/ArticleTranslation.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace NumaxLab\Geslib\Lines;
+
+use NumaxLab\Geslib\TypeCast;
+
+class ArticleTranslation implements LineInterface
+{
+    const CODE = 'ATRA';
+
+    private readonly Action $action;
+    private readonly int $articleId;
+    private readonly string $languageId;
+    private readonly ?string $description;
+    private readonly ?string $externalDescription;
+
+    private function __construct(
+        Action $action,
+        int $articleId,
+        string $languageId,
+        ?string $description,
+        ?string $externalDescription
+    ) {
+        $this->action = $action;
+        $this->articleId = $articleId;
+        $this->languageId = $languageId;
+        $this->description = $description;
+        $this->externalDescription = $externalDescription;
+    }
+
+    public static function getCode(): string
+    {
+        return self::CODE;
+    }
+
+    public static function fromLine(array $line): self
+    {
+        $action = Action::fromCode($line[1]);
+
+        $articleId = TypeCast::integer($line[2]);
+
+        if ($action->isDelete()) {
+            // The problem description says languageId is not nullable,
+            // but for a delete action, only the primary key (articleId)
+            // and perhaps languageId might be present.
+            // Assuming for delete, we might only have articleId.
+            // If languageId is also required for delete, this needs adjustment.
+            // For now, to prevent errors with TypeCast::string(null) if $line[3] is not set:
+            $languageId = TypeCast::string($line[3] ?? ''); // Or handle more robustly
+            return self::createWithDeleteAction($articleId, $languageId);
+        }
+
+        return self::createWithAction(
+            $action,
+            $articleId,
+            TypeCast::string($line[3]),
+            TypeCast::string($line[4]),
+            TypeCast::string($line[5])
+        );
+    }
+
+    public static function createWithDeleteAction(int $articleId, string $languageId): self
+    {
+        // As per previous comment, if languageId is truly part of the key for deletion.
+        // If not, the signature and instantiation might change.
+        return new self(Action::fromCode(Action::DELETE), $articleId, $languageId, null, null);
+    }
+
+    public static function createWithAction(
+        Action $action,
+        int $articleId,
+        string $languageId,
+        ?string $description,
+        ?string $externalDescription
+    ): self {
+        return new self(
+            $action,
+            $articleId,
+            $languageId,
+            $description,
+            $externalDescription
+        );
+    }
+
+    public function action(): Action
+    {
+        return $this->action;
+    }
+
+    public function articleId(): int
+    {
+        return $this->articleId;
+    }
+
+    public function languageId(): string
+    {
+        return $this->languageId;
+    }
+
+    public function description(): ?string
+    {
+        return $this->description;
+    }
+
+    public function externalDescription(): ?string
+    {
+        return $this->externalDescription;
+    }
+}

--- a/Lines/ArticleTranslation.php
+++ b/Lines/ArticleTranslation.php
@@ -8,20 +8,17 @@ class ArticleTranslation implements LineInterface
 {
     const CODE = 'ATRA';
 
-    private readonly Action $action;
     private readonly int $articleId;
     private readonly string $languageId;
     private readonly ?string $description;
     private readonly ?string $externalDescription;
 
     private function __construct(
-        Action $action,
         int $articleId,
         string $languageId,
         ?string $description,
-        ?string $externalDescription
+        ?string $externalDescription,
     ) {
-        $this->action = $action;
         $this->articleId = $articleId;
         $this->languageId = $languageId;
         $this->description = $description;
@@ -35,56 +32,12 @@ class ArticleTranslation implements LineInterface
 
     public static function fromLine(array $line): self
     {
-        $action = Action::fromCode($line[1]);
-
-        $articleId = TypeCast::integer($line[2]);
-
-        if ($action->isDelete()) {
-            // The problem description says languageId is not nullable,
-            // but for a delete action, only the primary key (articleId)
-            // and perhaps languageId might be present.
-            // Assuming for delete, we might only have articleId.
-            // If languageId is also required for delete, this needs adjustment.
-            // For now, to prevent errors with TypeCast::string(null) if $line[3] is not set:
-            $languageId = TypeCast::string($line[3] ?? ''); // Or handle more robustly
-            return self::createWithDeleteAction($articleId, $languageId);
-        }
-
-        return self::createWithAction(
-            $action,
-            $articleId,
+        return new self(
+            TypeCast::integer($line[1]),
+            TypeCast::string($line[2]),
             TypeCast::string($line[3]),
             TypeCast::string($line[4]),
-            TypeCast::string($line[5])
         );
-    }
-
-    public static function createWithDeleteAction(int $articleId, string $languageId): self
-    {
-        // As per previous comment, if languageId is truly part of the key for deletion.
-        // If not, the signature and instantiation might change.
-        return new self(Action::fromCode(Action::DELETE), $articleId, $languageId, null, null);
-    }
-
-    public static function createWithAction(
-        Action $action,
-        int $articleId,
-        string $languageId,
-        ?string $description,
-        ?string $externalDescription
-    ): self {
-        return new self(
-            $action,
-            $articleId,
-            $languageId,
-            $description,
-            $externalDescription
-        );
-    }
-
-    public function action(): Action
-    {
-        return $this->action;
     }
 
     public function articleId(): int

--- a/Tests/Lines/ArticleTranslationTest.php
+++ b/Tests/Lines/ArticleTranslationTest.php
@@ -1,0 +1,154 @@
+<?php
+
+namespace NumaxLab\Geslib\Tests\Lines;
+
+use NumaxLab\Geslib\Lines\Action;
+use NumaxLab\Geslib\Lines\ArticleTranslation;
+use PHPUnit\Framework\TestCase;
+
+class ArticleTranslationTest extends TestCase
+{
+    public function testFromLineWithAllFields()
+    {
+        $line = [
+            null, // Not used
+            'N', // Action
+            '12345', // articleId
+            'ENG', // languageId
+            'This is a description.', // description
+            'This is an external description.' // externalDescription
+        ];
+
+        $articleTranslation = ArticleTranslation::fromLine($line);
+
+        $this->assertInstanceOf(ArticleTranslation::class, $articleTranslation);
+        $this->assertEquals(Action::fromCode('N'), $articleTranslation->action());
+        $this->assertEquals(12345, $articleTranslation->articleId());
+        $this->assertEquals('ENG', $articleTranslation->languageId());
+        $this->assertEquals('This is a description.', $articleTranslation->description());
+        $this->assertEquals('This is an external description.', $articleTranslation->externalDescription());
+    }
+
+    public function testFromLineWithNullableFieldsAsEmpty()
+    {
+        $line = [
+            null,
+            'N',
+            '54321',
+            'SPA',
+            '', // description
+            ''  // externalDescription
+        ];
+
+        $articleTranslation = ArticleTranslation::fromLine($line);
+
+        $this->assertInstanceOf(ArticleTranslation::class, $articleTranslation);
+        $this->assertEquals(54321, $articleTranslation->articleId());
+        $this->assertEquals('SPA', $articleTranslation->languageId());
+        $this->assertNull($articleTranslation->description());
+        $this->assertNull($articleTranslation->externalDescription());
+    }
+
+    public function testFromLineWithNullableFieldsAsNullEquivalentInRawGeslib()
+    {
+        // Depending on how Geslib represents "null" for strings (could be empty, or a specific marker)
+        // Assuming empty strings are the way to represent null for these fields.
+        $line = [
+            null,
+            'M', // Action
+            '98765', // articleId
+            'FRA', // languageId
+            null, // description (TypeCast::string(null) becomes null)
+            null  // externalDescription (TypeCast::string(null) becomes null)
+        ];
+
+        $articleTranslation = ArticleTranslation::fromLine($line);
+
+        $this->assertInstanceOf(ArticleTranslation::class, $articleTranslation);
+        $this->assertEquals(Action::fromCode('M'), $articleTranslation->action());
+        $this->assertEquals(98765, $articleTranslation->articleId());
+        $this->assertEquals('FRA', $articleTranslation->languageId());
+        $this->assertNull($articleTranslation->description());
+        $this->assertNull($articleTranslation->externalDescription());
+    }
+
+    public function testCreateWithDeleteAction()
+    {
+        $articleTranslation = ArticleTranslation::createWithDeleteAction(11122, 'GER');
+
+        $this->assertInstanceOf(ArticleTranslation::class, $articleTranslation);
+        $this->assertEquals(Action::fromCode(Action::DELETE), $articleTranslation->action());
+        $this->assertEquals(11122, $articleTranslation->articleId());
+        $this->assertEquals('GER', $articleTranslation->languageId());
+        $this->assertNull($articleTranslation->description());
+        $this->assertNull($articleTranslation->externalDescription());
+    }
+
+    public function testFromLineWithDeleteAction()
+    {
+        // For delete, Geslib might only send key fields.
+        // The implementation of ArticleTranslation::fromLine assumes articleId and languageId are present.
+        $line = [
+            null,
+            'B', // Action (Delete)
+            '33344', // articleId
+            'ITA'  // languageId
+            // Other fields might be missing or empty for a delete operation
+        ];
+
+        $articleTranslation = ArticleTranslation::fromLine($line);
+
+        $this->assertInstanceOf(ArticleTranslation::class, $articleTranslation);
+        $this->assertEquals(Action::fromCode(Action::DELETE), $articleTranslation->action());
+        $this->assertEquals(33344, $articleTranslation->articleId());
+        $this->assertEquals('ITA', $articleTranslation->languageId());
+        $this->assertNull($articleTranslation->description());
+        $this->assertNull($articleTranslation->externalDescription());
+    }
+
+    public function testCreateWithAction()
+    {
+        $action = Action::fromCode('N');
+        $articleTranslation = ArticleTranslation::createWithAction(
+            $action,
+            777,
+            'POR',
+            'Portuguese Description',
+            'Portuguese External Description'
+        );
+
+        $this->assertEquals($action, $articleTranslation->action());
+        $this->assertEquals(777, $articleTranslation->articleId());
+        $this->assertEquals('POR', $articleTranslation->languageId());
+        $this->assertEquals('Portuguese Description', $articleTranslation->description());
+        $this->assertEquals('Portuguese External Description', $articleTranslation->externalDescription());
+    }
+
+    public function testGetters()
+    {
+        $action = Action::fromCode('M');
+        $articleId = 123;
+        $languageId = 'JPN';
+        $description = 'Japanese description';
+        $externalDescription = 'External Japanese description';
+
+        $articleTranslation = ArticleTranslation::createWithAction(
+            $action,
+            $articleId,
+            $languageId,
+            $description,
+            $externalDescription
+        );
+
+        $this->assertEquals($action, $articleTranslation->action());
+        $this->assertEquals($articleId, $articleTranslation->articleId());
+        $this->assertEquals($languageId, $articleTranslation->languageId());
+        $this->assertEquals($description, $articleTranslation->description());
+        $this->assertEquals($externalDescription, $articleTranslation->externalDescription());
+    }
+
+    public function testGetCode()
+    {
+        $this->assertEquals('ATRA', ArticleTranslation::getCode());
+    }
+}

--- a/Tests/Lines/ArticleTranslationTest.php
+++ b/Tests/Lines/ArticleTranslationTest.php
@@ -2,7 +2,6 @@
 
 namespace NumaxLab\Geslib\Tests\Lines;
 
-use NumaxLab\Geslib\Lines\Action;
 use NumaxLab\Geslib\Lines\ArticleTranslation;
 use PHPUnit\Framework\TestCase;
 
@@ -11,140 +10,20 @@ class ArticleTranslationTest extends TestCase
     public function testFromLineWithAllFields()
     {
         $line = [
-            null, // Not used
-            'N', // Action
-            '12345', // articleId
-            'ENG', // languageId
-            'This is a description.', // description
-            'This is an external description.' // externalDescription
+            ArticleTranslation::CODE,
+            12345,
+            '007',
+            'This is a description.',
+            'This is an external description.',
         ];
 
         $articleTranslation = ArticleTranslation::fromLine($line);
 
         $this->assertInstanceOf(ArticleTranslation::class, $articleTranslation);
-        $this->assertEquals(Action::fromCode('N'), $articleTranslation->action());
         $this->assertEquals(12345, $articleTranslation->articleId());
-        $this->assertEquals('ENG', $articleTranslation->languageId());
+        $this->assertEquals('007', $articleTranslation->languageId());
         $this->assertEquals('This is a description.', $articleTranslation->description());
         $this->assertEquals('This is an external description.', $articleTranslation->externalDescription());
-    }
-
-    public function testFromLineWithNullableFieldsAsEmpty()
-    {
-        $line = [
-            null,
-            'N',
-            '54321',
-            'SPA',
-            '', // description
-            ''  // externalDescription
-        ];
-
-        $articleTranslation = ArticleTranslation::fromLine($line);
-
-        $this->assertInstanceOf(ArticleTranslation::class, $articleTranslation);
-        $this->assertEquals(54321, $articleTranslation->articleId());
-        $this->assertEquals('SPA', $articleTranslation->languageId());
-        $this->assertNull($articleTranslation->description());
-        $this->assertNull($articleTranslation->externalDescription());
-    }
-
-    public function testFromLineWithNullableFieldsAsNullEquivalentInRawGeslib()
-    {
-        // Depending on how Geslib represents "null" for strings (could be empty, or a specific marker)
-        // Assuming empty strings are the way to represent null for these fields.
-        $line = [
-            null,
-            'M', // Action
-            '98765', // articleId
-            'FRA', // languageId
-            null, // description (TypeCast::string(null) becomes null)
-            null  // externalDescription (TypeCast::string(null) becomes null)
-        ];
-
-        $articleTranslation = ArticleTranslation::fromLine($line);
-
-        $this->assertInstanceOf(ArticleTranslation::class, $articleTranslation);
-        $this->assertEquals(Action::fromCode('M'), $articleTranslation->action());
-        $this->assertEquals(98765, $articleTranslation->articleId());
-        $this->assertEquals('FRA', $articleTranslation->languageId());
-        $this->assertNull($articleTranslation->description());
-        $this->assertNull($articleTranslation->externalDescription());
-    }
-
-    public function testCreateWithDeleteAction()
-    {
-        $articleTranslation = ArticleTranslation::createWithDeleteAction(11122, 'GER');
-
-        $this->assertInstanceOf(ArticleTranslation::class, $articleTranslation);
-        $this->assertEquals(Action::fromCode(Action::DELETE), $articleTranslation->action());
-        $this->assertEquals(11122, $articleTranslation->articleId());
-        $this->assertEquals('GER', $articleTranslation->languageId());
-        $this->assertNull($articleTranslation->description());
-        $this->assertNull($articleTranslation->externalDescription());
-    }
-
-    public function testFromLineWithDeleteAction()
-    {
-        // For delete, Geslib might only send key fields.
-        // The implementation of ArticleTranslation::fromLine assumes articleId and languageId are present.
-        $line = [
-            null,
-            'B', // Action (Delete)
-            '33344', // articleId
-            'ITA'  // languageId
-            // Other fields might be missing or empty for a delete operation
-        ];
-
-        $articleTranslation = ArticleTranslation::fromLine($line);
-
-        $this->assertInstanceOf(ArticleTranslation::class, $articleTranslation);
-        $this->assertEquals(Action::fromCode(Action::DELETE), $articleTranslation->action());
-        $this->assertEquals(33344, $articleTranslation->articleId());
-        $this->assertEquals('ITA', $articleTranslation->languageId());
-        $this->assertNull($articleTranslation->description());
-        $this->assertNull($articleTranslation->externalDescription());
-    }
-
-    public function testCreateWithAction()
-    {
-        $action = Action::fromCode('N');
-        $articleTranslation = ArticleTranslation::createWithAction(
-            $action,
-            777,
-            'POR',
-            'Portuguese Description',
-            'Portuguese External Description'
-        );
-
-        $this->assertEquals($action, $articleTranslation->action());
-        $this->assertEquals(777, $articleTranslation->articleId());
-        $this->assertEquals('POR', $articleTranslation->languageId());
-        $this->assertEquals('Portuguese Description', $articleTranslation->description());
-        $this->assertEquals('Portuguese External Description', $articleTranslation->externalDescription());
-    }
-
-    public function testGetters()
-    {
-        $action = Action::fromCode('M');
-        $articleId = 123;
-        $languageId = 'JPN';
-        $description = 'Japanese description';
-        $externalDescription = 'External Japanese description';
-
-        $articleTranslation = ArticleTranslation::createWithAction(
-            $action,
-            $articleId,
-            $languageId,
-            $description,
-            $externalDescription
-        );
-
-        $this->assertEquals($action, $articleTranslation->action());
-        $this->assertEquals($articleId, $articleTranslation->articleId());
-        $this->assertEquals($languageId, $articleTranslation->languageId());
-        $this->assertEquals($description, $articleTranslation->description());
-        $this->assertEquals($externalDescription, $articleTranslation->externalDescription());
     }
 
     public function testGetCode()


### PR DESCRIPTION
Implemented the new ATRA line type with fields: articleId (int), languageId (string), description (string, nullable), and externalDescription (string, nullable).

- Created Lines/ArticleTranslation.php with the class definition.
- Registered the new line type in LineFactory.php.
- Added Tests/Lines/ArticleTranslationTest.php with unit tests.

Note: Tests could not be run due to limitations in the execution environment.